### PR TITLE
fixes "Cannot read property 'code' of undefined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var topstories = function() {
     var url = 'http://api.nytimes.com/svc/topstories/v1/' + sec + '.json?' + 'api-key=' + this.key;
     var res = httpGet(url);
 
-    var resc = res.error.code;
+    var resc = res && res.error && res.error.code || null;
 
     if (resc === 403) {
       cb(new Error('Account Inactive'));


### PR DESCRIPTION
Error shows when we attempt to read the error code on a nonexistent error object.
